### PR TITLE
Fix: RACE-3 Q1 answer from B to A

### DIFF
--- a/RACE-3.md
+++ b/RACE-3.md
@@ -114,7 +114,7 @@ contract InSecureumNFT {
 (C): May burn the newly minted NFTs  
 (D): None of the above  
 
-**[Answers]: B**
+**[Answers]: A**
 
 ---
 


### PR DESCRIPTION
I believe, Race 3 [Q1] Answer is incorrectly marked as B, it should rather be A.  The require condition in `startSale` is incorrect so anyone can start a sale, provided they set price to 0. This is also supported by the correct option A in Q8.

Let me know if I'm missing anything.